### PR TITLE
Update composer.json to fix bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,9 @@
     ],
     "extra": {
         "installer-paths": {
+            "vendor/wordpress/wordpress/": [
+                "wordpress/wordpress"
+            ],
             "vendor/wordpress/wordpress-ext/wp-content/mu-plugins/{$name}/": [
                 "automattic/batcache",
                 "wpackagist-plugin/redis-cache",


### PR DESCRIPTION
Thank you for the great repo. I recently updated my repo and on pushing to heroku I had this error message.

`> ./support/app_slug_compile.sh`
`Bug: cp: cannot stat 'vendor/wordpress/wordpress/*': No such file or directory`

I suspect the wordpress installation default directory could have changed or something.

I fixed it by adding a installation path in composer.json. Hope it is the right approach.
